### PR TITLE
MATHJAX-14: Upgrade to MathJax v3.2.2

### DIFF
--- a/macro-mathjax-ui/pom.xml
+++ b/macro-mathjax-ui/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.webjars.npm</groupId>
       <artifactId>mathjax</artifactId>
-      <version>2.7.1</version>
+      <version>3.2.2</version>
       <scope>runtime</scope>
     </dependency>
     <!-- Required by wiki macros -->

--- a/macro-mathjax-ui/src/main/resources/Macros/MathJaxMacro.xml
+++ b/macro-mathjax-ui/src/main/resources/Macros/MathJaxMacro.xml
@@ -136,35 +136,51 @@ y = \frac{c}{cb-ad}
       <cache>long</cache>
     </property>
     <property>
-      <code>// Configure MathJax before it's loaded
-// See http://docs.mathjax.org/en/latest/configuration.html
-window.MathJax = {
-  displayAlign: "left",
-  displayIndent: "2em",
-  elements: document.getElementsByClassName("xwiki-mathjax"),
-  TeX: { equationNumbers: { autoNumber: "AMS" } }
-};
-
-// Load MathJax from its WebJar.
-require(["$services.webjars.url('org.webjars.npm:mathjax', 'MathJax.js', { 'config' : 'TeX-AMS_HTML' })"], function() {
-  // The MathJax library adds some DIVs at the start of the BODY element (in order to display messages) and this leads
-  // to empty pages when exporting to PDF even when no message is displayed because they are not hidden (height: 1px).
-  // The best practice is to inject such DIVs at the end of the BODY element, which this clean-up function does.
-  const cleanUp = function() {
-    // Move the hidden MathJax containers at the end of the BODY element.
-    const containers = document.querySelectorAll('body &gt; div &gt; #MathJax_Hidden, body &gt; div &gt; #MathJax_SVG_Hidden');
-    containers.forEach(function(container) {
-      document.body.appendChild(container.parentNode);
-    });
+      <code>define('configMathjax', function() {
+  // See http://docs.mathjax.org/en/latest/configuration.html
+  window.MathJax = {
+    chtml: {
+      displayAlign: "left",
+      displayIndent: "2em"
+    },
+    startup: {
+      elements: document.getElementsByClassName("xwiki-mathjax")
+    },
+    tex: {
+      tags: "ams",
+      autoload: {
+        color: [],
+        colorv2: ['color']
+      },
+      packages: {'[+]': ['noerrors']}
+    },
+    options: {
+      ignoreHtmlClass: 'tex2jax_ignore',
+      processHtmlClass: 'tex2jax_process'
+    },
+    loader: {
+      load: ['[tex]/noerrors']
+    }
   };
+});
 
+// Configure MathJax before loading it.
+require.config({
+  paths: {
+    'mathjax': "$services.webjars.url('org.webjars.npm:mathjax', 'es5/tex-chtml.js')"
+  },
+  shim: {
+    'mathjax': ['configMathjax']
+  }
+});
+
+require(["jquery", 'mathjax'], function($, math) {
   // Delay the page ready until all formulas are generated, if supported.
   if (require.defined('xwiki-page-ready')) {
     require(['xwiki-page-ready'], function(pageReady) {
       pageReady.delayPageReady(new Promise(function(resolve, reject) {
-        // See http://docs.mathjax.org/en/v2.7-latest/advanced/queues.html#the-mathjax-processing-queue
-        MathJax.Hub.Queue(function() {
-          cleanUp();
+        // See https://docs.mathjax.org/en/latest/web/configuration.html#performing-actions-after-typesetting
+        MathJax.startup.promise.then(() =&gt; {
           resolve();
         });
       }), 'MathJax');

--- a/macro-mathjax-ui/src/main/resources/Macros/MathJaxMacro.xml
+++ b/macro-mathjax-ui/src/main/resources/Macros/MathJaxMacro.xml
@@ -196,8 +196,6 @@ require(["jquery", 'mathjax'], function($, math) {
       MathJax.texReset();
       MathJax.typesetPromise(elems);
     }).catch((err) =&gt; console.log('Typeset failed: ' + err.message));
-
-    return promise;
   };
 
   $(document).on('xwiki:dom:updated', function(e, data) {

--- a/macro-mathjax-ui/src/main/resources/Macros/MathJaxMacro.xml
+++ b/macro-mathjax-ui/src/main/resources/Macros/MathJaxMacro.xml
@@ -175,21 +175,22 @@ require.config({
 });
 
 require(["jquery", 'mathjax'], function($, math) {
+  var promise = Promise.resolve();
   // Delay the page ready until all formulas are generated, if supported.
   if (require.defined('xwiki-page-ready')) {
+    promise = new Promise(function(resolve, reject) {
+      // See https://docs.mathjax.org/en/latest/web/configuration.html#performing-actions-after-typesetting
+      MathJax.startup.promise.then(() =&gt; {
+        resolve();
+      });
+    });
     require(['xwiki-page-ready'], function(pageReady) {
-      pageReady.delayPageReady(new Promise(function(resolve, reject) {
-        // See https://docs.mathjax.org/en/latest/web/configuration.html#performing-actions-after-typesetting
-        MathJax.startup.promise.then(() =&gt; {
-          resolve();
-        });
-      }), 'MathJax');
+      pageReady.delayPageReady(promise, 'MathJax');
     });
   }
 
   // Chain typesetting calls, since multiple simultaneously asynchronous typesetting calls can produce errors.
   // See https://docs.mathjax.org/en/latest/web/typeset.html#handling-asynchronous-typesetting.
-  let promise = Promise.resolve();
   var typeset = function(elems) {
     promise = promise.then(() =&gt; {
       // Reset the tex labels, since re-typesetting might create duplicate labels.

--- a/macro-mathjax-ui/src/main/resources/Macros/MathJaxMacro.xml
+++ b/macro-mathjax-ui/src/main/resources/Macros/MathJaxMacro.xml
@@ -178,7 +178,7 @@ require(["jquery", 'mathjax'], function($, math) {
   var promise = Promise.resolve();
   // Delay the page ready until all formulas are generated, if supported.
   if (require.defined('xwiki-page-ready')) {
-    promise = new Promise(function(resolve, reject) {
+    promise = new Promise(function(resolve) {
       // See https://docs.mathjax.org/en/latest/web/configuration.html#performing-actions-after-typesetting
       MathJax.startup.promise.then(() =&gt; {
         resolve();
@@ -195,7 +195,7 @@ require(["jquery", 'mathjax'], function($, math) {
     promise = promise.then(() =&gt; {
       // Reset the tex labels, since re-typesetting might create duplicate labels.
       MathJax.texReset();
-      MathJax.typesetPromise(elems);
+      return MathJax.typesetPromise(elems);
     }).catch((err) =&gt; console.log('Typeset failed: ' + err.message));
   };
 
@@ -338,7 +338,7 @@ require(["jquery", 'mathjax'], function($, math) {
     </class>
     <property>
       <code>{{velocity}}
-$xwiki.jsx.use('Macros.MathJaxMacro')
+$xwiki.jsx.use('Macros.MathJaxMacro', {'wysiwyg': true})
 
 {{html clean='true'}}
 #if ($wikimacro.context.isInline())

--- a/macro-mathjax-ui/src/main/resources/Macros/MathJaxMacro.xml
+++ b/macro-mathjax-ui/src/main/resources/Macros/MathJaxMacro.xml
@@ -186,6 +186,26 @@ require(["jquery", 'mathjax'], function($, math) {
       }), 'MathJax');
     });
   }
+
+  // Chain typesetting calls, since multiple simultaneously asynchronous typesetting calls can produce errors.
+  // See https://docs.mathjax.org/en/latest/web/typeset.html#handling-asynchronous-typesetting.
+  let promise = Promise.resolve();
+  var typeset = function(elems) {
+    promise = promise.then(() =&gt; {
+      // Reset the tex labels, since re-typesetting might create duplicate labels.
+      MathJax.texReset();
+      MathJax.typesetPromise(elems);
+    }).catch((err) =&gt; console.log('Typeset failed: ' + err.message));
+
+    return promise;
+  };
+
+  $(document).on('xwiki:dom:updated', function(e, data) {
+    let mathElems = data.elements.flatMap(x =&gt; {
+      return x.hasClassName('xwiki-mathjax') ? [x] : [...x.querySelectorAll('.xwiki-mathjax')];
+    });
+    typeset(mathElems);
+  });
 });</code>
     </property>
     <property>


### PR DESCRIPTION
MATHJAX-4: WYSIWYG Editor To Display Formulas Nicely
* update the mathjax configuration to be compatible with v3
* some configurations were generated from the old config file TeX-AMS_HTML, using the conversion tool proposed by them when upgrading from v2 https://mathjax.github.io/MathJax-demos-web/convert-configuration/convert-configuration.html
* use MathJax.startup.promise to know when mathjax has finished typesetting
* re-typeset the page on dom:updated event

Still in progress: This depends on https://jira.xwiki.org/browse/XWIKI-20183 and should be merged after the issue is fixed and the xwiki parent version is upgraded to the fix version