### PR TITLE
MATHJAX-21: The macro is not interpreted in rendered diff view

### DIFF
--- a/macro-mathjax-ui/src/main/resources/Macros/MathJaxMacro.xml
+++ b/macro-mathjax-ui/src/main/resources/Macros/MathJaxMacro.xml
@@ -136,7 +136,7 @@ y = \frac{c}{cb-ad}
       <cache>long</cache>
     </property>
     <property>
-      <code>define('configMathjax', function() {
+      <code>define('configMathjax', ['jquery'], function($) {
   // See http://docs.mathjax.org/en/latest/configuration.html
   // In order to avoid https://github.com/mathjax/MathJax/issues/2999, the 'elements' configuration was removed. Right
   // now, a ignoreHtmlClass was added to the body, in order to force Mathjax to typeset only elements that have the
@@ -149,8 +149,27 @@ y = \frac{c}{cb-ad}
     startup: {
       pageReady() {
         document.body.classList.add('mathjax-ignore');
-        return MathJax.startup.defaultPageReady();
-      }
+        // Since the same macro will be displayed twice in a rendered diff, we typeset each one individually in order to
+        // avoid errors from duplicate labels. This will produce some inconsistences with the displayed equation
+        // numbers, meaning that each macro will start counting from 0 and anchor ids will be duplicated.
+        if ($('#renderedChanges').length &gt; 0) {
+          let promise = MathJax.startup.defaultPageReady();
+          $('.xwiki-mathjax').each((i, el) =&gt; {
+            // Mathjax doesn't typesets math code mixed with html content.
+            el.innerHTML = el.textContent;
+            promise = promise.then(() =&gt; {
+              // Reset the tex labels.
+              MathJax.texReset();
+              return MathJax.typesetPromise([el]);
+            });
+          });
+          return promise;
+       } else {
+         // Let MathJax handle typeset.
+         return MathJax.startup.defaultPageReady();
+       }
+      },
+      typeset: $('#renderedChanges').length &gt; 0 ? false : true
     },
     tex: {
       tags: "ams",

--- a/macro-mathjax-ui/src/main/resources/Macros/MathJaxMacro.xml
+++ b/macro-mathjax-ui/src/main/resources/Macros/MathJaxMacro.xml
@@ -151,7 +151,7 @@ y = \frac{c}{cb-ad}
         document.body.classList.add('mathjax-ignore');
         // Since the same macro will be displayed twice in a rendered diff, we typeset each one individually in order to
         // avoid errors from duplicate labels. This will produce some inconsistences with the displayed equation
-        // numbers, meaning that each macro will start counting from 0 and anchor ids will be duplicated.
+        // numbers, meaning that each macro will start counting from 1 and anchor ids will be duplicated.
         if ($('#renderedChanges').length &gt; 0) {
           let promise = MathJax.startup.defaultPageReady();
           $('.xwiki-mathjax').each((i, el) =&gt; {

--- a/macro-mathjax-ui/src/main/resources/Macros/MathJaxMacro.xml
+++ b/macro-mathjax-ui/src/main/resources/Macros/MathJaxMacro.xml
@@ -169,7 +169,7 @@ y = \frac{c}{cb-ad}
          return MathJax.startup.defaultPageReady();
        }
       },
-      typeset: $('#renderedChanges').length &gt; 0 ? false : true
+      typeset: $('#renderedChanges').length &lt;= 0
     },
     tex: {
       tags: "ams",


### PR DESCRIPTION
* do the typeset manually in the rendered diff view, in order to reset tex labels after each macro; this is a workaround to not have duplicate labels errors, considering that each macro will be displayed twice

This is an example of rendered diff view. Note the problems that were explained in a code comment:
`This will produce some inconsistences with the displayed equation numbers, meaning that each macro will start counting from 1 and anchor ids will be duplicated.`
![image](https://user-images.githubusercontent.com/22794181/224346408-ba3d29d1-4cfe-48cd-9c49-3e2aa8cf1846.png)
